### PR TITLE
Corrected the answer to Exercise 1 Part c

### DIFF
--- a/chapter 1/chapter1-1.md
+++ b/chapter 1/chapter1-1.md
@@ -137,7 +137,7 @@ P ∧ ¬S = I will buy the Pant but not the shirt.
 
 (c)
 
-(¬P ∨ ¬S) ∧ ¬(¬P ∧ ¬Q) = Either I won't buy the pant or won't buy the shirt. (XOR)
+(¬P ∨ ¬S) ∧ ¬(¬P ∧ ¬Q) = Either I won't buy the pant or won't buy the shirt.
 
 Exercise 6
 -----------

--- a/chapter 1/chapter1-1.md
+++ b/chapter 1/chapter1-1.md
@@ -182,9 +182,7 @@ C = Pete will win the chemistry prize.
 Premises:
 
 ¬ (J ∧ P)
-
 (P ∨ C) ∧ ¬(P ∧ C)
-
 J
 
 Conclusion:
@@ -209,7 +207,6 @@ T|F|T|T|
 T|T|F|T|
 T|T|T|T|
 
-Truth table verifies our answer.
 
 (b)
 
@@ -220,37 +217,15 @@ C = Corn will be the vegetable.
 
 Premises:
 (B ∨ F) ∧ ¬(B ∧ F)
-
 (P ∨ C) ∧ ¬(P ∧ C)
-
 ¬(F ∧ C)
 
 Conclusion:
-
 ¬(B ∧ P)
 
 Reasoning seems invalid: In a case where you cannot have both fish and
 corn, you will end up with Beef and Peas.
 
-
-B|C|P|F|((((B ∨ F) ∧ ¬(B ∧ F)) ∧ (((P ∨ C) ∧ ¬(P ∧ C)) ∧ ¬(F ∧ C))) → ¬(B ∧ P))|
-|---|---|---|---|---|
-F|F|F|F|T|
-F|F|F|T|T|
-F|F|T|F|T|
-F|F|T|T|T|
-F|T|F|F|T|
-F|T|F|T|T|
-F|T|T|F|T|
-F|T|T|T|T|
-T|F|F|F|T|
-T|F|F|T|T|
-T|F|T|F|F|
-T|F|T|T|T|
-T|T|F|F|T|
-T|T|F|T|T|
-T|T|T|F|T|
-T|T|T|T|T|
 
 (c)
 
@@ -259,27 +234,13 @@ B = Bill is telling the truth.
 S = Sam is telling the truth.
 
 Premises:
-
 (J ∨ B) ∧ ¬(J ∧ B)
-
 (¬S ∨ ¬B) ∧ ¬(¬S ∧ ¬B)
 
 Conclusion:
-
 (J ∨ ¬S) ∧ ¬(J ∧ ¬S)
 
 Reasoning seems valid: J ∨ B ∨ ¬S ∨ ¬B gives J ∨ ¬S
-
-B|J|S|((((J ∨ B) ∧ ¬(J ∧ B)) ∧ ((¬S ∨ ¬B) ∧ ¬(¬S ∧ ¬B))) → ((J ∨ ¬S) ∧ ¬(J ∧ ¬S)))|
-|---|---|---|---|---|
-F|F|F|T|
-F|F|T|T|
-F|T|F|T|
-F|T|T|T|
-T|F|F|T|
-T|F|T|T|
-T|T|F|T|
-T|T|T|T|
 
 
 (d) Either sales will go up and the boss will be happy, or expenses will go
@@ -291,23 +252,10 @@ B = Boss will be happy.
 E = Expenses will go up.
 
 Premises:
-
 (S ∧ B) ∨ (E ∧ ¬B)
 
 Conclusion:
-
 ¬(S ∧ E)
 
-Reasoning is invalid: When S = T, E = T, B = T, them premise is True
+Reasoning is invalide: When S = T, E = T, B = T, them premise is True
 and Conclusion is false.
-
-B|E|S|(((S ∧ B) ∨ (E ∧ ¬B)) → ¬(S ∧ E))|
-|---|---|---|---|---|
-F|F|F|T|
-F|F|T|T|
-F|T|F|T|
-F|T|T|F|
-T|F|F|T|
-T|F|T|T|
-T|T|F|T|
-T|T|T|F|

--- a/chapter 1/chapter1-1.md
+++ b/chapter 1/chapter1-1.md
@@ -98,7 +98,9 @@ A ∧ B = Alice and Bob are both in the room
 
 (c)
 
-¬A ∨ ¬B
+'Either Alice or Bob is not in the room.', translates to 'Either Alice is not in the room or Bob is not in the room, but it is not the case that both are missing from the room.'. This is captured by xor.
+
+(¬A ∨ ¬B) ∧ ¬(¬A ∧ ¬B)  
 
 (d)
 
@@ -135,7 +137,7 @@ P ∧ ¬S = I will buy the Pant but not the shirt.
 
 (c)
 
-¬P ∨ ¬S = Either I won't buy the pant or won't buy the shirt.
+(¬P ∨ ¬S) ∧ ¬(¬P ∧ ¬Q) = Either I won't buy the pant or won't buy the shirt. (XOR)
 
 Exercise 6
 -----------
@@ -180,7 +182,7 @@ C = Pete will win the chemistry prize.
 Premises:
 
 ¬ (J ∧ P)
-P ∨ C
+(P ∨ C) ∧ ¬(P ∧ C)
 J
 
 Conclusion:
@@ -190,6 +192,23 @@ Reasoning is valid: Jane has won the math prize so Pete can't win the
 math prize. So he can only will the chemistry prize according to the
 premises.
 
+Alternatively we can prove the statement using a truthtable,
+when we have to prove that a sequence of statements conclude an argument,
+the logical and (conjunction) of all the premises must imply the conclusion.
+
+C|J|P|((¬(J ∧ P) ∧ ((P ∧ C) ∧ (¬(P ∧ C) ∧ J))) → C)|
+|---|---|---|---|---|
+F|F|F|T|
+F|F|T|T|
+F|T|F|T|
+F|T|T|T|
+T|F|F|T|
+T|F|T|T|
+T|T|F|T|
+T|T|T|T|
+
+Truth table verifies our answer.
+
 (b)
 
 B = Beef will be the main course.
@@ -198,8 +217,8 @@ P = Peas will be the vegetable.
 C = Corn will be the vegetable.
 
 Premises:
-B ∨ F
-P ∨ C
+(B ∨ F) ∧ ¬(B ∧ F)
+(P ∨ C) ∧ ¬(P ∧ C)
 ¬(F ∧ C)
 
 Conclusion:
@@ -208,6 +227,26 @@ Conclusion:
 Reasoning seems invalid: In a case where you cannot have both fish and
 corn, you will end up with Beef and Peas.
 
+
+B|C|P|Q|((((B ∨ Q) ∧ ¬(B ∧ Q)) ∧ (((P ∨ C) ∧ ¬(P ∧ C)) ∧ ¬(Q ∧ C))) → ¬(B ∧ P))|
+|---|---|---|---|---|
+F|F|F|F|T|
+F|F|F|T|T|
+F|F|T|F|T|
+F|F|T|T|T|
+F|T|F|F|T|
+F|T|F|T|T|
+F|T|T|F|T|
+F|T|T|T|T|
+T|F|F|F|T|
+T|F|F|T|T|
+T|F|T|F|F|
+T|F|T|T|T|
+T|T|F|F|T|
+T|T|F|T|T|
+T|T|T|F|T|
+T|T|T|T|T|
+
 (c)
 
 J = John is telling the truth.
@@ -215,13 +254,25 @@ B = Bill is telling the truth.
 S = Sam is telling the truth.
 
 Premises:
-J ∨ B
-¬S ∨ ¬B
+(J ∨ B) ∧ ¬(J ∧ B)
+(¬S ∨ ¬B) ∧ ¬(¬S ∧ ¬B)
 
 Conclusion:
-J ∨ ¬S
+(J ∨ ¬S) ∧ ¬(J ∧ ¬S)
 
 Reasoning seems valid: J ∨ B ∨ ¬S ∨ ¬B gives J ∨ ¬S
+
+B|J|S|((((J ∨ B) ∧ ¬(J ∧ B)) ∧ ((¬S ∨ ¬B) ∧ ¬(¬S ∧ ¬B))) → ((J ∨ ¬S) ∧ ¬(J ∧ ¬S)))|
+|---|---|---|---|---|
+F|F|F|T|
+F|F|T|T|
+F|T|F|T|
+F|T|T|T|
+T|F|F|T|
+T|F|T|T|
+T|T|F|T|
+T|T|T|T|
+
 
 (d) Either sales will go up and the boss will be happy, or expenses will go
 up and the boss won’t be happy. Therefore, sales and expenses will not
@@ -237,5 +288,16 @@ Premises:
 Conclusion:
 ¬(S ∧ E)
 
-Reasoning is invalide: When S = T, E = T, B = T, them premise is True
+Reasoning is invalid: When S = T, E = T, B = T, them premise is True
 and Conclusion is false.
+
+B|E|S|(((S ∧ B) ∨ (E ∧ ¬B)) → ¬(S ∧ E))|
+|---|---|---|---|---|
+F|F|F|T|
+F|F|T|T|
+F|T|F|T|
+F|T|T|F|
+T|F|F|T|
+T|F|T|T|
+T|T|F|T|
+T|T|T|F|

--- a/chapter 1/chapter1-1.md
+++ b/chapter 1/chapter1-1.md
@@ -100,7 +100,7 @@ A ∧ B = Alice and Bob are both in the room
 
 'Either Alice or Bob is not in the room.', translates to 'Either Alice is not in the room or Bob is not in the room, but it is not the case that both are missing from the room.'. This is captured by xor.
 
-(¬A ∨ ¬B) ∧ ¬(¬A ∧ ¬B)  
+(¬A ∨ ¬B) ∧ ¬(¬A ∧ ¬B)
 
 (d)
 
@@ -214,7 +214,6 @@ Conclusion:
 Reasoning seems invalid: In a case where you cannot have both fish and
 corn, you will end up with Beef and Peas.
 
-
 (c)
 
 J = John is telling the truth.
@@ -229,7 +228,6 @@ Conclusion:
 (J ∨ ¬S) ∧ ¬(J ∧ ¬S)
 
 Reasoning seems valid: J ∨ B ∨ ¬S ∨ ¬B gives J ∨ ¬S
-
 
 (d) Either sales will go up and the boss will be happy, or expenses will go
 up and the boss won’t be happy. Therefore, sales and expenses will not

--- a/chapter 1/chapter1-1.md
+++ b/chapter 1/chapter1-1.md
@@ -182,7 +182,9 @@ C = Pete will win the chemistry prize.
 Premises:
 
 ¬ (J ∧ P)
+
 (P ∨ C) ∧ ¬(P ∧ C)
+
 J
 
 Conclusion:
@@ -218,17 +220,20 @@ C = Corn will be the vegetable.
 
 Premises:
 (B ∨ F) ∧ ¬(B ∧ F)
+
 (P ∨ C) ∧ ¬(P ∧ C)
+
 ¬(F ∧ C)
 
 Conclusion:
+
 ¬(B ∧ P)
 
 Reasoning seems invalid: In a case where you cannot have both fish and
 corn, you will end up with Beef and Peas.
 
 
-B|C|P|Q|((((B ∨ Q) ∧ ¬(B ∧ Q)) ∧ (((P ∨ C) ∧ ¬(P ∧ C)) ∧ ¬(Q ∧ C))) → ¬(B ∧ P))|
+B|C|P|F|((((B ∨ F) ∧ ¬(B ∧ F)) ∧ (((P ∨ C) ∧ ¬(P ∧ C)) ∧ ¬(F ∧ C))) → ¬(B ∧ P))|
 |---|---|---|---|---|
 F|F|F|F|T|
 F|F|F|T|T|
@@ -254,10 +259,13 @@ B = Bill is telling the truth.
 S = Sam is telling the truth.
 
 Premises:
+
 (J ∨ B) ∧ ¬(J ∧ B)
+
 (¬S ∨ ¬B) ∧ ¬(¬S ∧ ¬B)
 
 Conclusion:
+
 (J ∨ ¬S) ∧ ¬(J ∧ ¬S)
 
 Reasoning seems valid: J ∨ B ∨ ¬S ∨ ¬B gives J ∨ ¬S
@@ -283,9 +291,11 @@ B = Boss will be happy.
 E = Expenses will go up.
 
 Premises:
+
 (S ∧ B) ∨ (E ∧ ¬B)
 
 Conclusion:
+
 ¬(S ∧ E)
 
 Reasoning is invalid: When S = T, E = T, B = T, them premise is True

--- a/chapter 1/chapter1-1.md
+++ b/chapter 1/chapter1-1.md
@@ -196,18 +196,6 @@ Alternatively we can prove the statement using a truthtable,
 when we have to prove that a sequence of statements conclude an argument,
 the logical and (conjunction) of all the premises must imply the conclusion.
 
-C|J|P|((¬(J ∧ P) ∧ ((P ∧ C) ∧ (¬(P ∧ C) ∧ J))) → C)|
-|---|---|---|---|---|
-F|F|F|T|
-F|F|T|T|
-F|T|F|T|
-F|T|T|T|
-T|F|F|T|
-T|F|T|T|
-T|T|F|T|
-T|T|T|T|
-
-
 (b)
 
 B = Beef will be the main course.

--- a/chapter 1/section1-3.md
+++ b/chapter 1/section1-3.md
@@ -28,7 +28,7 @@ D(x,y) = x is divisible by y
 N(x) = x is a natural number.
 P(x) = x is a prime number
 
-    N(x) ∧ N(y) ∧ (P(x) ∨ P(y))
+    N(x) ∧ N(y) ∧ (((P(x) ∨ P(y)) ∧ (¬P(x) ∨ ¬P(y)))
 
 Exercise 2
 ----------


### PR DESCRIPTION
The question is `x and y are natural numbers, and exactly one of them is prime.`, the current answer is wrong as it also includes the case when both x and y are prime, I have used xor connective as opposed to or connective to capture the predicate `exactly one of them is prime`.