### PR TITLE
Section 3-1.

### DIFF
--- a/chapter 3/section3.1.tex
+++ b/chapter 3/section3.1.tex
@@ -116,7 +116,7 @@ Hypotheses:
 
 Conclusion: $2n + 13$ is not a prime number
 
-Counterexample: When $n = 3$, $2n + 13 = 19$ which is a prime number.
+Counterexample: When $n = 8$, $2n + 13 = 29$ which is a prime number.
 
 \section{Problem 4}
 


### PR DESCRIPTION
The premise says that n cannot be a prime number, but 3 is a prime, which makes the initial counterexample incorrect.