### PR TITLE
Problem in Excercise 1 Question 3

### DIFF
--- a/chapter 1/section1-3.md
+++ b/chapter 1/section1-3.md
@@ -28,7 +28,9 @@ D(x,y) = x is divisible by y
 N(x) = x is a natural number.
 P(x) = x is a prime number
 
-    N(x) ∧ N(y) ∧ (P(x) ∨ P(y))
+    N(x) ∧ N(y) ∧ (P(x) ⊕ P(y))
+    
+    ⊕ is symbol for exclusive or. It will true when "only one" of its operand is true.
 
 Exercise 2
 ----------


### PR DESCRIPTION
The statement in question is "x and y are natural numbers, and **exactly one of them** is prime."
So, we have to use Exclusive or instead of Inclusive or which is true even when both of its operands are true.